### PR TITLE
Expose tileSize parameter in getTFBS()

### DIFF
--- a/code/getTFBS.R
+++ b/code/getTFBS.R
@@ -306,6 +306,7 @@ setGeneric("getTFBS",
                     chunkSize = 2000, # Number of regions per chunk
                     chunkInds = NULL, # Whether to only run the model on a specific subset of chunks. If so, provide chunk indices here
                     innerChunkSize = 10, # Number of regions per inner chunk
+                    tileSize = 10, # Size of tiles if sites is NULL
                     nCores = 16 # Number of cores to use
            ) standardGeneric("getTFBS"))
 
@@ -317,6 +318,7 @@ setMethod("getTFBS",
                    chunkSize = 2000,
                    chunkInds = NULL,
                    innerChunkSize = 10,
+                   tileSize = 10,
                    nCores = 16) {
             
             # Directory for storing intermediate results
@@ -425,6 +427,7 @@ setMethod("getTFBS",
                                     region = regions[regionInd],
                                     dispModels = dispModels,
                                     TFBSModel = TFBSModel,
+                                    tileSize = tileSize,
                                     sites = sites)
                       
                     }


### PR DESCRIPTION
Hi,

I use PRINT to calculate the TFBS at individual SNPs, and therefore set tileSize = 1 when calling TFBS. However, currently there is no way of changing this parameter without editing the hard-coded value of 10. This PR exposes the tileSize parameter in getRegionTFBS() to the user function getTFBS().